### PR TITLE
Update Amazon IVS Player SDK to 1.22.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,6 @@
 platform :ios, '14.0'
 
 target 'Grid Feed' do
-    pod 'AmazonIVSPlayer', '~> 1.21.0'
+    pod 'AmazonIVSPlayer', '~> 1.22.0'
     pod 'SDWebImage', '~> 5.0', modular_headers: true
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - AmazonIVSPlayer (1.21.0)
+  - AmazonIVSPlayer (1.22.0)
   - SDWebImage (5.18.1):
     - SDWebImage/Core (= 5.18.1)
   - SDWebImage/Core (5.18.1)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.21.0)
+  - AmazonIVSPlayer (~> 1.22.0)
   - SDWebImage (~> 5.0)
 
 SPEC REPOS:
@@ -14,9 +14,9 @@ SPEC REPOS:
     - SDWebImage
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: 85ebbc42536999322ffe5a50de17e850dc6d0a93
+  AmazonIVSPlayer: 9bc23db8a5dfcf844aae2e59c2d528e8f36fe2f2
   SDWebImage: ebdbcebc7933a45226d9313bd0118bc052ad458b
 
-PODFILE CHECKSUM: 33e8db72234cf103c3e3bd52d82871a1ed96e5b4
+PODFILE CHECKSUM: a81f6e631a2498693dfd74f9c966b42e8319262c
 
 COCOAPODS: 1.12.0


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.22.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
